### PR TITLE
v1.2 Alias support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ php:
  - 7.1
  - 7.2
  - 7.3
+ - 7.4
  - hhvm
  - nightly
 
 before_script:
  - composer self-update
  - composer install --prefer-source --no-interaction --dev
+ - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer require --dev --no-update phpunit/phpunit ~7; fi
 
 script:
  - ./vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,5 @@
 language: php
 
-matrix:
-  include:
-    - php: 7.1
-      env:
-        - LEGACY_DEPS="phpunit/phpunit=^7"
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4
-
 before_script:
  - composer self-update
  - composer install --prefer-source --no-interaction --dev
@@ -18,6 +9,14 @@ script:
  - ./vendor/bin/phpunit --coverage-text
 
 matrix:
+ include:
+  - php: 7.1
+    env:
+      - LEGACY_DEPS="phpunit/phpunit=^7"
+  - php: 7.2
+  - php: 7.3
+  - php: 7.4
+
  allow_failures:
   - php: hhvm
   - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
- - 7.0
  - 7.1
  - 7.2
  - 7.3
@@ -13,7 +12,7 @@ before_script:
  - composer install --prefer-source --no-interaction --dev
 
 script:
- - phpunit --coverage-text
+ - ./vendor/bin/phpunit --coverage-text
 
 matrix:
  allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 before_script:
  - composer self-update 
- - php -r "file_put_contents('composer.json', str_replace('phpunit/phpunit\": \"^8.0', 'phpunit/phpunit\": \"$PHPUNIT_VERSION', file_get_contents('composer.json')));"
+ - 'php -r "file_put_contents(''composer.json'', str_replace(''phpunit/phpunit\":\"^8.0'', ''phpunit/phpunit\": \"$PHPUNIT_VERSION'', file_get_contents(''composer.json'')));"'
  - composer install --prefer-source --no-interaction --dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,14 @@ matrix:
     env:
       - PHPUNIT_VERSION="^7.0"
   - php: 7.2
+    env:
+      - PHPUNIT_VERSION="^8.0"
   - php: 7.3
+    env:
+      - PHPUNIT_VERSION="^8.0"
   - php: 7.4
+    env:
+      - PHPUNIT_VERSION="^9.0"
 
  allow_failures:
   - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 before_script:
- - composer self-update
+ - composer self-update 
  - php -r "file_put_contents('composer.json', str_replace('phpunit/phpunit\": \"^8.0', 'phpunit/phpunit\": \"$PHPUNIT_VERSION', file_get_contents('composer.json')));"
  - composer install --prefer-source --no-interaction --dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 before_script:
  - composer self-update
- - composer install --prefer-source --no-interaction --dev
  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update--with-dependencies $LEGACY_DEPS ; fi
+ - composer install --prefer-source --no-interaction --dev
 
 script:
  - ./vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 language: php
 
-php:
- - 7.1
- - 7.2
- - 7.3
- - 7.4
- - hhvm
- - nightly
+matrix:
+  include:
+    - php: 7.0
+      env:
+        - LEGACY_DEPS="phpunit/phpunit=^7"
+    - php: 7.1
+      env:
+        - LEGACY_DEPS="phpunit/phpunit=^7"
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
 
 before_script:
  - composer self-update
  - composer install --prefer-source --no-interaction --dev
- - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer require --dev --no-update phpunit/phpunit ~7; fi
+ - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update--with-dependencies $LEGACY_DEPS ; fi
 
 script:
  - ./vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 7.0
-      env:
-        - LEGACY_DEPS="phpunit/phpunit=^7"
     - php: 7.1
       env:
         - LEGACY_DEPS="phpunit/phpunit=^7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 before_script:
  - composer self-update 
- - 'php -r "file_put_contents(''composer.json'', str_replace(''phpunit/phpunit\":\"^8.0'', ''phpunit/phpunit\": \"$PHPUNIT_VERSION'', file_get_contents(''composer.json'')));"'
+ - 'php -r "file_put_contents(''composer.json'', str_replace(''phpunit/phpunit\": \"^8.0'', ''phpunit/phpunit\": \"$PHPUNIT_VERSION'', file_get_contents(''composer.json'')));"'
  - composer install --prefer-source --no-interaction --dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 before_script:
  - composer self-update
- - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update--with-dependencies $LEGACY_DEPS ; fi
+ - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update --with-dependencies $LEGACY_DEPS ; fi
  - composer install --prefer-source --no-interaction --dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 before_script:
  - composer self-update
- - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update --with-dependencies $LEGACY_DEPS ; fi
+ - php -r "file_put_contents('composer.json', str_replace('phpunit/phpunit\": \"^8.0', 'phpunit/phpunit\": \"$PHPUNIT_VERSION', file_get_contents('composer.json')));"
  - composer install --prefer-source --no-interaction --dev
 
 script:
@@ -12,7 +12,7 @@ matrix:
  include:
   - php: 7.1
     env:
-      - LEGACY_DEPS="phpunit/phpunit=^7"
+      - PHPUNIT_VERSION="^7.0"
   - php: 7.2
   - php: 7.3
   - php: 7.4

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": ">=7.1"
 	},
     "require-dev": {
-        "phpunit/phpunit": "7.0"
+        "phpunit/phpunit": "^8.0"
     },
 	"autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,11 @@
 	"description": "ClanCats IoC Container.",
 	"license": "MIT",
 	"require": {
-		"php": ">=7.0"
+		"php": ">=7.1"
 	},
+    "require-dev": {
+        "phpunit/phpunit": "7.0"
+    },
 	"autoload": {
         "psr-4": {
         	"ClanCats\\Container\\": "src/"

--- a/src/Container.php
+++ b/src/Container.php
@@ -67,7 +67,7 @@ class Container
      *
      * @var array[string => string]
      */
-    private $serviceAliases = [];
+    protected $serviceAliases = [];
 
     /**
      * Array of already resolved shared factories

--- a/src/Container.php
+++ b/src/Container.php
@@ -36,6 +36,7 @@ class Container
     const RESOLVE_FACTORY = 2;
     const RESOLVE_SHARED = 3;
     const RESOLVE_SETTER = 4;
+    const RESOLVE_ALIAS = 5;
     protected $serviceResolverType = [];
 
     /**
@@ -60,6 +61,13 @@ class Container
      * @var array[ServiceFactoryInterface|Closure]
      */
     private $resolverFactories = [];
+
+    /**
+     * An array of service name aliases
+     *
+     * @var array[string => string]
+     */
+    private $serviceAliases = [];
 
     /**
      * Array of already resolved shared factories
@@ -341,6 +349,9 @@ class Container
         if (isset($this->resolverFactories[$serviceName])) {
             unset($this->resolverFactories[$serviceName]);
         }
+        if (isset($this->serviceAliases[$serviceName])) {
+            unset($this->serviceAliases[$serviceName]);
+        }
 
         return true;
     }
@@ -364,6 +375,10 @@ class Container
 
         if ($this->serviceResolverType[$serviceName] === static::RESOLVE_FACTORY) {
             return false;
+        }
+
+        if ($this->serviceResolverType[$serviceName] === static::RESOLVE_ALIAS) {
+            return $this->isResolved($this->serviceAliases[$serviceName]);
         }
 
         return isset($this->resolvedSharedServices[$serviceName]);
@@ -436,6 +451,10 @@ class Container
 
             case static::RESOLVE_SHARED:
                 return $this->resolveServiceShared($serviceName);
+            break;
+
+            case static::RESOLVE_ALIAS:
+                return $this->get($this->serviceAliases[$serviceName]);
             break;
 
             default:
@@ -601,6 +620,21 @@ class Container
     {
         $this->setServiceResolverType($name, static::RESOLVE_SHARED);
         $this->resolverFactories[$name] = $factory;
+    }
+
+    /**
+     * Creates an alias to another service
+     * Aliases act a bit special. They are able to hold alias specific meta data 
+     * But things like their resolved status will be forwarded from their target.
+     * 
+     * @param string                $name
+     * @param string                $targetService
+     * @return void
+     */
+    public function alias(string $name, string $targetService)
+    {
+        $this->setServiceResolverType($name, static::RESOLVE_ALIAS);
+        $this->serviceAliases[$name] = $targetService;
     }
 
     /**

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -46,6 +46,13 @@ class ContainerBuilder
     protected $parameters = [];
 
     /**
+     * An array of service aliases to be defined.
+     * 
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * An array of binded services
      * 
      * @param array[string => Service]
@@ -230,6 +237,9 @@ class ContainerBuilder
         // import the parameters
         $this->parameters = array_merge($this->parameters, $namespace->getParameters());
 
+        // import aliases
+        $this->aliases = array_merge($this->aliases, $namespace->getAliases());
+
         // import the service definitions
         foreach($namespace->getServices() as $name => $service)
         {
@@ -327,6 +337,7 @@ class ContainerBuilder
         $buffer .= "class $this->containerClassName extends $aliasContainerName {\n\n";
 
         $buffer .= $this->generateParameters() . "\n";
+        $buffer .= $this->generateAliases() . "\n";
         $buffer .= $this->generateMetaData() . "\n";
         $buffer .= $this->generateResolverTypes() . "\n";
         $buffer .= $this->generateResolverMappings() . "\n";
@@ -418,6 +429,16 @@ class ContainerBuilder
     }
 
     /**
+     * Generate the containers aliases property
+     * 
+     * @return string 
+     */
+    private function generateAliases() : string
+    {
+        return "protected \$serviceAliases = " . var_export($this->aliases, true) . ";\n";
+    }
+
+    /**
      * Generate the containers parameter property
      * 
      * @return string 
@@ -463,6 +484,12 @@ class ContainerBuilder
         foreach($this->services as $serviceName => $serviceDefinition)
         {
             $types[] = var_export($serviceName, true) . ' => ' . Container::RESOLVE_METHOD;
+        }
+
+        // also add the aliases
+        foreach($this->aliases as $serviceName => $targetService)
+        {
+            $types[] = var_export($serviceName, true) . ' => ' . Container::RESOLVE_ALIAS;
         }
 
         return "protected \$serviceResolverType = [" . implode(', ', $types) . "];\n";

--- a/src/ContainerNamespace.php
+++ b/src/ContainerNamespace.php
@@ -200,7 +200,7 @@ class ContainerNamespace
     public function parse(string $containerFilePath)
     {
         // create a lexer from the given file
-        $lexer = new ContainerLexer($this->getCodeFromFile($containerFilePath));
+        $lexer = new ContainerLexer($this->getCodeFromFile($containerFilePath), $containerFilePath);
 
         // parse the file
         $parser = new ScopeParser($lexer->tokens());

--- a/src/ContainerNamespace.php
+++ b/src/ContainerNamespace.php
@@ -33,6 +33,13 @@ class ContainerNamespace
     protected $parameters = [];
 
     /**
+     * The container service aliases
+     * 
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * The container namespaces service defintions
      * 
      * @param array[string => Service]
@@ -115,6 +122,39 @@ class ContainerNamespace
     public function getParameters() : array
     {
         return $this->parameters;
+    }
+
+    /**
+     * Does the container namespace have an alias with the given name?
+     * 
+     * @param string            $name The alias name.
+     * @return bool
+     */
+    public function hasAlias(string $name) : bool
+    {
+        return array_key_exists($name, $this->aliases);
+    }
+
+    /**
+     * Set the given alias and target
+     * 
+     * @param string            $name The alias name.
+     * @param mixed             $target The alias target.
+     * @return void
+     */
+    public function setAlias(string $name, $target) 
+    {
+        $this->aliases[$name] = $target;
+    }
+
+    /**
+     * Get all aliases from the container namespace
+     * 
+     * @return array
+     */
+    public function getAliases() : array
+    {
+        return $this->aliases;
     }
 
     /**

--- a/src/ContainerParser/ContainerInterpreter.php
+++ b/src/ContainerParser/ContainerInterpreter.php
@@ -188,7 +188,13 @@ class ContainerInterpreter
     {
         if ($this->namespace->hasService($definition->getName()) && $definition->isOverride() === false)
         {
-            throw new ContainerInterpreterException("A service named \"{$definition->getName()}\" is already defined, you can prefix the definition with \"override\" to get around this error.");
+            throw new ContainerInterpreterException("A service / alias named \"{$definition->getName()}\" is already defined, you can prefix the definition with \"override\" to get around this error.");
+        }
+
+        // special case if an alias is beeing defined
+        if ($definition->isAlias()) {
+            $this->namespace->setAlias($definition->getName(), $definition->getAliasTarget()->getName());
+            return;
         }
 
         // create a service definition from the node

--- a/src/ContainerParser/ContainerLexer.php
+++ b/src/ContainerParser/ContainerLexer.php
@@ -103,7 +103,7 @@ class ContainerLexer
         "/^(\-)/" => T::TOKEN_MINUS,
         "/^(\=)/" => T::TOKEN_EQUAL,
         "/^(\,)/" => T::TOKEN_SEPERATOR,
-        "/^(\?)/" => T::TOKEN_PROTOTYPE,
+        "/^(\?)/" => T::TOKEN_OPTIONAL,
 
         // ids
         "/^([\w\-\/\\\\.]+)/" => T::TOKEN_IDENTIFIER,

--- a/src/ContainerParser/ContainerLexer.php
+++ b/src/ContainerParser/ContainerLexer.php
@@ -46,6 +46,14 @@ class ContainerLexer
     protected $line = 0;
 
     /**
+     * The filename 
+     * This is mainly used for error messages. 
+     *
+     * @var string
+     */
+    protected $filename = 'unknown';
+
+    /**
      * Token map
      *
      * @var array
@@ -107,7 +115,7 @@ class ContainerLexer
      * @var string         $code
      * @return void
      */
-    public function __construct(string $code)
+    public function __construct(string $code, $filename = null)
     {
         // there is never a need for tabs or multiple whitespaces 
         // so we remove them before assigning the code
@@ -115,6 +123,11 @@ class ContainerLexer
 
         // we need to know the codes length
         $this->length = strlen($this->code);
+
+        // assign the filename
+        if ($filename) {
+            $this->filename = $filename;
+        }
     }
 
     /**
@@ -151,11 +164,11 @@ class ContainerLexer
 
                 $this->offset += strlen($matches[0]);
 
-                return new T($this->line + 1, $token, $matches[0]);
+                return new T($this->line + 1, $token, $matches[0], $this->filename);
             }
         }
 
-        throw new ContainerLexerException(sprintf('Unexpected character "%s" on line %s', $this->code[$this->offset], $this->line));
+        throw new ContainerLexerException(sprintf('Unexpected character "%s" on line %s in file %s', $this->code[$this->offset], $this->line, $this->filename));
     }
 
     /**

--- a/src/ContainerParser/ContainerParser.php
+++ b/src/ContainerParser/ContainerParser.php
@@ -308,7 +308,7 @@ class ContainerParser
         $class = new \ReflectionClass($token);
         $constants = array_flip($class->getConstants());
 
-        return new ContainerParserException('unexpected "' . $constants[$token->getType()] . '" given at line ' . $token->getLine());
+        return new ContainerParserException('unexpected "' . $constants[$token->getType()] . '" given at line ' . $token->getLine() . ' in file ' . $token->getFilename());
     }
 
     /**

--- a/src/ContainerParser/Nodes/ServiceDefinitionNode.php
+++ b/src/ContainerParser/Nodes/ServiceDefinitionNode.php
@@ -13,7 +13,8 @@ use ClanCats\Container\Exceptions\LogicalNodeException;
 use ClanCats\Container\ContainerParser\{
     Nodes\ValueNode,
     Nodes\ConstructionActionNode,
-    Nodes\MetaDataAssignmentNode
+    Nodes\MetaDataAssignmentNode,
+    Nodes\ServiceReferenceNode
 };
 
 class ServiceDefinitionNode extends BaseNode
@@ -33,11 +34,25 @@ class ServiceDefinitionNode extends BaseNode
     protected $className;
 
     /**
+     * The services alias target
+     * 
+     * @param ServiceReferenceNode
+     */
+    protected $aliasTarget = null;
+
+    /**
      * Does this definition override existing ones?
      * 
      * @var bool
      */
     protected $isOverride = false;
+
+    /**
+     * In case of an alias the className hold the alias target
+     * 
+     * @var bool
+     */
+    protected $isAlias = false;
 
     /**
      * An array of arguments to be passed on the services construction
@@ -104,13 +119,33 @@ class ServiceDefinitionNode extends BaseNode
     }
 
     /**
-     * Get the services class name
+     * Set the services class name
      * 
      * @return string
      */
     public function setClassName(string $className) 
     {
         $this->className = $className;
+    }
+
+    /**
+     * Get the services alias target name
+     * 
+     * @return ServiceReferenceNode
+     */
+    public function getAliasTarget() : ?ServiceReferenceNode 
+    {
+        return $this->aliasTarget;
+    }
+
+    /**
+     * Set the services alias target name
+     * 
+     * @return ServiceReferenceNode
+     */
+    public function setAliasTarget(ServiceReferenceNode $aliasTarget) 
+    {
+        $this->aliasTarget = $aliasTarget;
     }
 
     /**
@@ -132,6 +167,27 @@ class ServiceDefinitionNode extends BaseNode
     public function setIsOverride(bool $isOverride)
     {
         $this->isOverride = $isOverride;
+    }
+
+    /**
+     * Get if this definition is an alias to another one
+     * 
+     * @return bool 
+     */
+    public function isAlias() : bool
+    {
+        return $this->isAlias;
+    }
+
+    /**
+     * Set if this definition is an alias to another one
+     * 
+     * @param bool          $isAlias
+     * @return void
+     */
+    public function setIsAlias(bool $isAlias)
+    {
+        $this->isAlias = $isAlias;
     }
 
     /**

--- a/src/ContainerParser/Token.php
+++ b/src/ContainerParser/Token.php
@@ -61,7 +61,7 @@ class Token
     const TOKEN_SCOPE_CLOSE = 17;
     const TOKEN_MINUS = 18;
     const TOKEN_SEPERATOR = 19;
-    const TOKEN_PROTOTYPE = 20;
+    const TOKEN_OPTIONAL = 20;
     const TOKEN_IDENTIFIER = 21;
     const TOKEN_EQUAL = 22;
 

--- a/src/ContainerParser/Token.php
+++ b/src/ContainerParser/Token.php
@@ -32,6 +32,13 @@ class Token
     protected $line = 0;
 
     /**
+     * The tokens filename
+     * 
+     * @var string  
+     */
+    protected $filename;
+
+    /**
      * The token types
      */
     const TOKEN_STRING = 0;
@@ -64,13 +71,15 @@ class Token
      * @param int       $line The line the token is on.
      * @param int       $type The type of the token represented by an int.
      * @param mixed     $value The Value of the token.
+     * @param string     $filename The filename the token belongs to
      * @return void
      */
-    public function __construct(int $line, int $type, $value)
+    public function __construct(int $line, int $type, $value, ?string $filename = null)
     {
         $this->line = $line;
         $this->type = $type;
         $this->value = $value;
+        $this->filename = $filename;
     }
 
     /**
@@ -81,6 +90,16 @@ class Token
     public function getLine() : int
     {
         return $this->line;
+    }
+
+    /**
+     * Get the filename of the token
+     * 
+     * @return int
+     */
+    public function getFilename() : ?string
+    {
+        return $this->filename;
     }
 
     /**

--- a/tests/ContainerBuilderTest.php
+++ b/tests/ContainerBuilderTest.php
@@ -451,6 +451,19 @@ class ContainerBuilderTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsStringProxy("'airport' => 'TXL'", $builder->generate());
     }
 
+    public function testImportAliases()
+    {
+        $namespace = new ContainerNamespace();
+        $namespace->setAlias('logger', 'logger.default');
+        $namespace->setAlias('db', 'db.connector.mysql');
+
+        $builder = new ContainerBuilder('TestContainer');
+        $builder->importNamespace($namespace);
+
+        $this->assertStringContainsStringProxy("'logger' => 'logger.default'", $builder->generate());
+        $this->assertStringContainsStringProxy("'db' => 'db.connector.mysql'", $builder->generate());
+    }
+
     public function testImportNamespaceServices()
     {
         $namespace = new ContainerNamespace();

--- a/tests/ContainerNamespaceTest.php
+++ b/tests/ContainerNamespaceTest.php
@@ -27,6 +27,19 @@ class ContainerNamespaceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['foo' => 'bar'], $namespace->getParameters());
     }
 
+    public function testAlias()
+    {
+        $namespace = new ContainerNamespace();
+
+        $this->assertEquals([], $namespace->getAliases());
+        $this->assertFalse($namespace->hasAlias('foo'));
+
+        $namespace->setAlias('foo', 'bar');
+
+        $this->assertTrue($namespace->hasAlias('foo'));
+        $this->assertEquals(['foo' => 'bar'], $namespace->getAliases());
+    }
+
     public function testServices()
     {
         $namespace = new ContainerNamespace();

--- a/tests/ContainerParser/ContainerInterpreterTest.php
+++ b/tests/ContainerParser/ContainerInterpreterTest.php
@@ -124,6 +124,22 @@ class ContainerInterpreterTest extends \PHPUnit\Framework\TestCase
     	], $ns->getParameters());
     }
 
+    public function testHandleAliasDefinition()
+    {
+        $ns = new ContainerNamespace();
+        $interpreter = new ContainerInterpreter($ns);
+
+        $aliasdef = new ServiceDefinitionNode('foo');
+        $aliasdef->setIsAlias(true);
+        $aliasdef->setAliasTarget(new ServiceReferenceNode('bar'));
+
+        $interpreter->handleServiceDefinition($aliasdef);
+
+        $this->assertEquals([
+            'foo' => 'bar'
+        ], $ns->getAliases());
+    }
+
     public function testHandleParameterDefinitionWithoutOverride() 
     {
         $this->expectException(\ClanCats\Container\Exceptions\ContainerInterpreterException::class);

--- a/tests/ContainerParser/ContainerLexerTest.php
+++ b/tests/ContainerParser/ContainerLexerTest.php
@@ -114,7 +114,7 @@ class ContainerLexerTest extends LexerTestCase
     {
         $this->assertTokenTypes("@router?: Acme\\Router", [
             T::TOKEN_DEPENDENCY,
-            T::TOKEN_PROTOTYPE,
+            T::TOKEN_OPTIONAL,
             T::TOKEN_ASSIGN,
             T::TOKEN_SPACE,
             T::TOKEN_IDENTIFIER

--- a/tests/ContainerParser/Nodes/ServiceDefinitionNodeTest.php
+++ b/tests/ContainerParser/Nodes/ServiceDefinitionNodeTest.php
@@ -41,6 +41,15 @@ class ServiceDefinitionNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($node->isOverride());
     }
 
+    public function testAlias()
+    {
+        $node = new ServiceDefinitionNode();
+
+        $this->assertFalse($node->isAlias());
+        $node->setIsAlias(true);
+        $this->assertTrue($node->isAlias());
+    }
+
     public function testArguments()
     {
         $node = new ServiceDefinitionNode();

--- a/tests/ContainerParser/Parser/ServiceDefinitionParserTest.php
+++ b/tests/ContainerParser/Parser/ServiceDefinitionParserTest.php
@@ -69,6 +69,19 @@ class ServiceDefinitionParserTest extends ParserTestCase
         $this->assertTrue($def->isOverride());
     }
 
+    public function testAlias()
+    {
+        $def = $this->serviceDefnitionNodeFromCode('@logger: Acme\\Log');
+        $this->assertFalse($def->isAlias());
+
+        $this->assertEquals(null, $def->getAliasTarget());
+
+        $def = $this->serviceDefnitionNodeFromCode('@logger: @logger.default');
+        $this->assertTrue($def->isAlias());
+
+        $this->assertEquals('logger.default', $def->getAliasTarget()->getName());
+    }
+
     public function testMethodCalls()
     {
         $def = $this->serviceDefnitionNodeFromCode("@logger: Acme\\Log\n- setName('app')");
@@ -148,6 +161,6 @@ class ServiceDefinitionParserTest extends ParserTestCase
     public function testWrongAssignment() 
     {
         $this->expectException(\ClanCats\Container\Exceptions\ContainerParserException::class);
-        $this->serviceDefnitionNodeFromCode('@logger: @antoherone');
+        $this->serviceDefnitionNodeFromCode('@logger: :foo');
     }
 }

--- a/tests/ContainerParser/Parser/ServiceDefinitionParserTest.php
+++ b/tests/ContainerParser/Parser/ServiceDefinitionParserTest.php
@@ -82,6 +82,24 @@ class ServiceDefinitionParserTest extends ParserTestCase
         $this->assertEquals('logger.default', $def->getAliasTarget()->getName());
     }
 
+    public function testInvalidAliasDefinitionArguments() 
+    {
+        $this->expectException(\ClanCats\Container\Exceptions\ContainerParserException::class);
+        $this->serviceDefnitionNodeFromCode('logger: @logger.default("foo")');
+    }
+
+    public function testInvalidAliasDefinitionFunctionCall() 
+    {
+        $this->expectException(\ClanCats\Container\Exceptions\ContainerParserException::class);
+        $this->serviceDefnitionNodeFromCode("logger: @logger.default\n- setSomething()");
+    }
+
+    public function testInvalidAliasDefinitionMetaAssign() 
+    {
+        $this->expectException(\ClanCats\Container\Exceptions\ContainerParserException::class);
+        $this->serviceDefnitionNodeFromCode("logger: @logger.default\n= data");
+    }
+
     public function testMethodCalls()
     {
         $def = $this->serviceDefnitionNodeFromCode("@logger: Acme\\Log\n- setName('app')");

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -490,6 +490,18 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($container->isResolved('car.main'));
     }
 
+    public function testServiceAliasesRecursion()
+    {
+        $container = new Container();
+        $container->register(new CustomServiceProviderArray());
+
+        $container->alias('volvo', 'car');
+        $container->alias('volvo.s60', 'volvo');
+        $container->alias('my_car', 'volvo.s60');
+
+        $this->assertInstanceOf(Car::class, $container->get('my_car'));
+    }
+
     public function testServiceAliasMetaData()
     {
         $container = new Container();

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -455,4 +455,51 @@ class ContainerTest extends \PHPUnit\Framework\TestCase
             'bmw' => [['Cars']]
         ], $container->serviceNamesWithMetaData('tags'));
     }
+
+    public function testServiceAliases()
+    {
+        $container = new Container();
+        $container->register(new CustomServiceProviderArray());
+
+        $container->bind('car.default', function($c) {
+            return new Car($c->get('engine'));
+        });
+        $container->alias('car.main', 'car.default');
+
+        $this->assertTrue($container->has('car.default'));
+        $this->assertTrue($container->has('car.main'));
+
+        // try to resolve it 
+        $this->assertInstanceOf(Car::class, $container->get('car.default'));
+        $this->assertInstanceOf(Car::class, $container->get('car.main'));
+
+        // make sure they are the same
+        $this->assertSame($container->get('car.default'), $container->get('car.main'));
+
+        // test resolve status
+        $this->assertTrue($container->isResolved('car.default'));
+        $this->assertTrue($container->isResolved('car.main'));
+
+        // test removing an alias
+        $container->remove('car.main');
+        $this->assertFalse($container->has('car.main'));
+        $this->assertTrue($container->has('car.default'));
+
+        // test resolve status
+        $this->assertTrue($container->isResolved('car.default'));
+        $this->assertFalse($container->isResolved('car.main'));
+    }
+
+    public function testServiceAliasMetaData()
+    {
+        $container = new Container();
+        $container->register(new CustomServiceProviderArray());
+        $container->addMetaData('car', 'test', ['foo']);
+
+        $container->alias('car_alias', 'car');
+        $container->addMetaData('car_alias', 'test', ['foo_alias']); 
+
+        $this->assertEquals([['foo']], $container->getMetaData('car', 'test'));
+        $this->assertEquals([['foo_alias']], $container->getMetaData('car_alias', 'test'));
+    }
 }


### PR DESCRIPTION
Added support for service aliases. 

```php
$container->alias('db', 'connector.mysql');
```

Or with container files simply:

```
@db: @connector.mysql
```