### PR TITLE
Added Support for Service Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,40 @@ The elements inside the metadata definition can have named keys:
   = on: 'app.start' call: 'onAppStart'
 ```
 
+#### Service Updates
+
+It is possible to update already defined services with more construction calls and metadata. 
+This is quite handy to organize large amount of dependencies with a dynamic lookups.
+
+You could for example define your logger in one file.
+
+```php
+@logger.main: Acme\Logger
+```
+
+And add observers using a construction call where you need them.
+
+```php
+@logger.observers.email_devs: Acme\EmailLogObserver('dev@example.com')
+@logger.observers.email_support: Acme\EmailLogObserver('support@example.com')
+
+@logger.main
+  - addObserver(@logger.observers.email_devs)
+  - addObserver(@logger.observers.email_support)
+```
+
+The same is also true for metadata.
+
+```php
+@controller.homepage: Controller\Homepage
+  = on: '/homepage'
+
+
+// also show homepage on root
+@controller.homepage
+  = on: '/'
+```
+
 ### Imports
 
 Other container files can be imported from the container namespace.
@@ -745,7 +779,7 @@ import app.env
   - [ ] Property injection
   - [ ] Parameter concatination
   - [ ] Input Parameters (used for env detection)
-  - [ ] Late service override (allow for adding meta or arguments) 
+  - [х] Late service override (allow for adding meta or calls) 
   - [ ] macros
 - Container
   - [x] Metadata support

--- a/docs/20__Container_Files/10_Syntax.md
+++ b/docs/20__Container_Files/10_Syntax.md
@@ -172,6 +172,28 @@ The elements inside the metadata definition can have named keys:
   = on: 'app.start' call: 'onAppStart'
 ```
 
+### Service Updates
+
+It is possible to update already defined services with more construction calls and metadata. 
+This is quite handy to organize large amount of dependencies with a dynamic lookups.
+
+You could for example define your logger in one file.
+
+```yml
+@logger.main: Acme\Logger
+```
+
+And add observers using a construction call where you need them.
+
+```yml
+@logger.observers.email_devs: Acme\EmailLogObserver('dev@example.com')
+@logger.observers.email_support: Acme\EmailLogObserver('support@example.com')
+
+@logger.main
+  - addObserver(@logger.observers.email_devs)
+  - addObserver(@logger.observers.email_support)
+```
+
 ## Imports
 
 Other container files can be imported from the container namespace.

--- a/src/ContainerParser/ContainerInterpreter.php
+++ b/src/ContainerParser/ContainerInterpreter.php
@@ -186,7 +186,7 @@ class ContainerInterpreter
      */
     public function handleServiceDefinition(ServiceDefinitionNode $definition) 
     {
-        if ($this->namespace->hasService($definition->getName()) && $definition->isOverride() === false)
+        if ($this->namespace->hasService($definition->getName()) && $definition->isOverride() === false && $definition->isUpdate() === false)
         {
             throw new ContainerInterpreterException("A service / alias named \"{$definition->getName()}\" is already defined, you can prefix the definition with \"override\" to get around this error.");
         }
@@ -197,8 +197,21 @@ class ContainerInterpreter
             return;
         }
 
-        // create a service definition from the node
-        $service = new ServiceDefinition($definition->getClassName());
+        // create a new service or fetch an existing 
+        // one in case of an update
+        if ($definition->isUpdate()) 
+        {
+            if (!$this->namespace->hasService($definition->getName())) {
+                throw new ContainerInterpreterException("A service named \"{$definition->getName()}\" is beeing updated, but the service has not been defined yet.");
+            }
+
+            // fetch the existing service
+            $service = $this->namespace->getServices()[$definition->getName()];
+
+        } else  {
+            // create a service definition from the node
+            $service = new ServiceDefinition($definition->getClassName());
+        }
 
         if ($definition->hasArguments()) 
         {

--- a/src/ContainerParser/Nodes/ServiceDefinitionNode.php
+++ b/src/ContainerParser/Nodes/ServiceDefinitionNode.php
@@ -55,6 +55,13 @@ class ServiceDefinitionNode extends BaseNode
     protected $isAlias = false;
 
     /**
+     * The node only updates an already present service
+     *
+     * @var bool
+     */
+    protected $isUpdate = false;
+
+    /**
      * An array of arguments to be passed on the services construction
      * 
      * @var ArgumentArrayNode
@@ -188,6 +195,27 @@ class ServiceDefinitionNode extends BaseNode
     public function setIsAlias(bool $isAlias)
     {
         $this->isAlias = $isAlias;
+    }
+
+    /**
+     * Get if this definition is a service update
+     * 
+     * @return bool 
+     */
+    public function isUpdate() : bool
+    {
+        return $this->isUpdate;
+    }
+
+    /**
+     * Set if this definition is a service update
+     * 
+     * @param bool          $isUpdate
+     * @return void
+     */
+    public function setIsUpdate(bool $isUpdate)
+    {
+        $this->isUpdate = $isUpdate;
     }
 
     /**

--- a/src/ContainerParser/Parser/ServiceDefinitionParser.php
+++ b/src/ContainerParser/Parser/ServiceDefinitionParser.php
@@ -47,13 +47,16 @@ class ServiceDefinitionParser extends ContainerParser
 
         // set the name
         $definition->setName($serviceName);
+        
+        // skip the service name token
+        $this->skipToken();
 
         // if an assign token is present we have a real definition 
         // or alias in front of us. Otherwise it is just an update
-        if ($this->nextToken()->isType(T::TOKEN_ASSIGN))
+        if (!$this->parserIsDone() && $this->currentToken()->isType(T::TOKEN_ASSIGN))
         {
-            // at this point we can skip the name and assign character
-            $this->skipToken(2);
+            // at this point we can skip the assign character
+            $this->skipToken();
 
             // we might have a alias assignment here
             if ($this->currentToken()->isType(T::TOKEN_DEPENDENCY))

--- a/src/ContainerParser/Parser/ServiceDefinitionParser.php
+++ b/src/ContainerParser/Parser/ServiceDefinitionParser.php
@@ -48,41 +48,44 @@ class ServiceDefinitionParser extends ContainerParser
         // set the name
         $definition->setName($serviceName);
 
-        // now a assign ":" character must follow
-        if (!$this->nextToken()->isType(T::TOKEN_ASSIGN))
+        // if an assign token is present we have a real definition 
+        // or alias in front of us. Otherwise it is just an update
+        if ($this->nextToken()->isType(T::TOKEN_ASSIGN))
         {
-            throw $this->errorUnexpectedToken($this->nextToken());
+            // at this point we can skip the name and assign character
+            $this->skipToken(2);
+
+            // we might have a alias assignment here
+            if ($this->currentToken()->isType(T::TOKEN_DEPENDENCY))
+            {
+                $definition->setIsAlias(true);
+            }
+
+            // the next token must therefor be a identifier
+            elseif (!$this->currentToken()->isType(T::TOKEN_IDENTIFIER))
+            {
+                throw $this->errorUnexpectedToken($this->currentToken());
+            }
+
+            // assign the class name from the identifiers value
+            if ($definition->isAlias()) {
+                $definition->setAliasTarget($this->parseChild(ReferenceParser::class));
+            } else {
+                $definition->setClassName($this->currentToken()->getValue());
+            }
+            
+            $this->skipToken();
+
+            // try to parse service constructor arguments
+            if (!$this->parserIsDone() && $this->currentToken()->isType(T::TOKEN_BRACE_OPEN) && (!$definition->isAlias()))
+            {
+                $arguments = $this->parseChild(ArgumentArrayParser::class, $this->getTokensUntilClosingScope(), false);
+                $definition->setArguments($arguments);
+            }
         }
-
-        // at this point we can skip the name and assign character
-        $this->skipToken(2);
-
-        // we might have a alias assignment here
-        if ($this->currentToken()->isType(T::TOKEN_DEPENDENCY))
+        else 
         {
-            $definition->setIsAlias(true);
-        }
-
-        // the next token must therefor be a identifier
-        elseif (!$this->currentToken()->isType(T::TOKEN_IDENTIFIER))
-        {
-            throw $this->errorUnexpectedToken($this->currentToken());
-        }
-
-        // assign the class name from the identifiers value
-        if ($definition->isAlias()) {
-            $definition->setAliasTarget($this->parseChild(ReferenceParser::class));
-        } else {
-            $definition->setClassName($this->currentToken()->getValue());
-        }
-        
-        $this->skipToken();
-
-        // try to parse service constructor arguments
-        if (!$this->parserIsDone() && $this->currentToken()->isType(T::TOKEN_BRACE_OPEN) && (!$definition->isAlias()))
-        {
-            $arguments = $this->parseChild(ArgumentArrayParser::class, $this->getTokensUntilClosingScope(), false);
-            $definition->setArguments($arguments);
+            $definition->setIsUpdate(true);
         }
 
         // we need at least one linebreak to continue

--- a/tests/ContainerParser/Nodes/ServiceDefinitionNodeTest.php
+++ b/tests/ContainerParser/Nodes/ServiceDefinitionNodeTest.php
@@ -50,6 +50,15 @@ class ServiceDefinitionNodeTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($node->isAlias());
     }
 
+    public function testUpdate()
+    {
+        $node = new ServiceDefinitionNode();
+
+        $this->assertFalse($node->isUpdate());
+        $node->setIsUpdate(true);
+        $this->assertTrue($node->isUpdate());
+    }
+
     public function testArguments()
     {
         $node = new ServiceDefinitionNode();

--- a/tests/ContainerParser/Parser/ServiceDefinitionParserTest.php
+++ b/tests/ContainerParser/Parser/ServiceDefinitionParserTest.php
@@ -123,6 +123,18 @@ class ServiceDefinitionParserTest extends ParserTestCase
         $this->assertEquals('setLevel', $actions[1]->getName());
     }
 
+    public function testMultipleMethodCallsServiceUpdate()
+    {
+        $def = $this->serviceDefnitionNodeFromCode("@logger\n- setName('app')\n- setLevel(1)");
+
+        $actions = $def->getConstructionActions();
+
+        $this->assertCount(2, $actions);
+        $this->assertTrue($def->isUpdate());
+        $this->assertEquals('setName', $actions[0]->getName());
+        $this->assertEquals('setLevel', $actions[1]->getName());
+    }
+
     public function testMetaDataAssignments()
     {
         $def = $this->serviceDefnitionNodeFromCode("@logger: Acme\\Log\n= listen: 'kernel.exception'");
@@ -131,6 +143,17 @@ class ServiceDefinitionParserTest extends ParserTestCase
 
         $this->assertCount(1, $meta);
 
+        $this->assertEquals('listen', $meta[0]->getKey());
+    }
+
+    public function testMetaDataAssignmentsServiceUpdate()
+    {
+        $def = $this->serviceDefnitionNodeFromCode("@logger\n= listen: 'kernel.exception'");
+
+        $meta = $def->getMetaDataAssignemnts();
+
+        $this->assertCount(1, $meta);
+        $this->assertTrue($def->isUpdate());
         $this->assertEquals('listen', $meta[0]->getKey());
     }
 
@@ -170,10 +193,13 @@ class ServiceDefinitionParserTest extends ParserTestCase
         $this->serviceDefnitionNodeFromCode('logger: Acme\\Log');
     }
 
-    public function testMissingAssignIndicator() 
+    public function testServiceIsUpdate() 
     {
-        $this->expectException(\ClanCats\Container\Exceptions\ContainerParserException::class);
-        $this->serviceDefnitionNodeFromCode('@logger Acme\\Log');
+        $def = $this->serviceDefnitionNodeFromCode('@logger');
+        $this->assertTrue($def->isUpdate());
+
+        $def = $this->serviceDefnitionNodeFromCode('@logger: Acme\\Log');
+        $this->assertFalse($def->isUpdate());
     }
 
     public function testWrongAssignment() 


### PR DESCRIPTION
It is possible to update already defined services with more construction calls and metadata. 
This is quite handy to organize large amount of dependencies with a dynamic lookups.

You could for example define your logger in one file.

```php
@logger.main: Acme\Logger
```

And add observers using a construction call where you need them.

```php
@logger.observers.email_devs: Acme\EmailLogObserver('dev@example.com')
@logger.observers.email_support: Acme\EmailLogObserver('support@example.com')

@logger.main
  - addObserver(@logger.observers.email_devs)
  - addObserver(@logger.observers.email_support)
```

The same is also true for metadata.

```php
@controller.homepage: Controller\Homepage
  = on: '/homepage'


// also show homepage on root
@controller.homepage
  = on: '/'
```